### PR TITLE
Check that response exists before enhancing original response error

### DIFF
--- a/src/axiosBetterStacktrace.ts
+++ b/src/axiosBetterStacktrace.ts
@@ -61,7 +61,7 @@ const axiosBetterStacktrace = (axiosInstance?: AxiosInstance, opts: { errorMsg?:
   // enhance original response error with a topmostError stack trace
   const responseErrorInterceptorId = axiosInstance.interceptors.response.use(
     (response) => {
-      if (response.config && isError(response.config.topmostError)) {
+      if (response && response.config && isError(response.config.topmostError)) {
         // remove topmostError to not clutter config and expose it to other interceptors down the chain
         delete response.config.topmostError;
       }


### PR DESCRIPTION
This package would be great for our project, though when attempting to implement [`axios-retry`](https://github.com/softonic/axios-retry) with this package, problems arise.  

If the instructions are followed and `axiosBetterStackTrace(axiosInstance)` is used before any other interceptors, `axios-retry` prevents better stack traces. If `axiosBetterStackTrace(axiosInstance)` is called after `axiosRetry({...})`, a better stack trace is indeed returned, though the following TypeError is thrown:

```
undefined is not an object (evaluating 't.config')
```

This happens due to a line of code in the `axiosBetterStacktrace()` function which checks for the existence of `response.config` before checking whether `response` exists. If we put a response interceptor between `axiosRetry()` and `axiosBetterStackTrace()` and log the response like:
```
axiosRetry({
    ...
});


globalAxiosInstance.interceptors.response.use(function (response) {
	console.log(response)
	return response;
});


axiosRetry(globalAxiosInstance);
```
We can see that response is undefined, which is why the error is thrown in `axiosBetterStackTrace.js`. If response is checked before checking if `response.config` exists, this problem can be avoided.


This change could be useful and help others using `axios-retry`, or some other third party package that behaves in a similar way, and still get better stack traces from Axios errors.